### PR TITLE
Remove dead asset MOBI

### DIFF
--- a/src/app/model/account.model.ts
+++ b/src/app/model/account.model.ts
@@ -16,7 +16,6 @@ export class Account {
 export const KnownAccounts = {
     "Firefly" : new Account("GCNY5OXYSY4FKHOPT2SPOQZAOEIGXB5LBYW3HVU3OWSTQITS65M5RCNY", "fchain.io"),
     "Interstellar" : new Account("GCNSGHUCG5VMGLT5RIYYZSO7VQULQKAJ62QA33DBC5PPBSO57LFWVV6P", "interstellar.exchange"),
-    "Mobius" : new Account("GA6HCMBLTZS5VYYBCATRBRZ3BZJMAFUDKYYF6AH6MVCMGWMRDNSWJPIH", "mobius.network"),
     "RippleFox" : new Account("GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX", "ripplefox.com"),
     "SmartLands": new Account("GCKA6K5PCQ6PNF5RQBF7PQDJWRHO6UOGFMRLK3DYHDOI244V47XKQ4GP", "smartlands.io"),
     "Stronghold" : new Account("GDSTRSHXHGJ7ZIVRBXEYE5Q74XUVCUSEKEBR7UCHEUUEK72N7I7KJ6JH", "stronghold.co"),

--- a/src/app/model/asset.model.ts
+++ b/src/app/model/asset.model.ts
@@ -48,7 +48,6 @@ export const KnownAssets = {
     "CNY-RippleFox" : new Asset("CNY", "Chinese Yuan", "credit_alphanum4", KnownAccounts.RippleFox),
     "ETH-fchain" : new Asset("ETH", "Ethereum", null, new Account("GBETHKBL5TCUTQ3JPDIYOZ5RDARTMHMEKIO2QZQ7IOZ4YC5XV3C2IKYU", "fchain.io")),
     "EURT" : new Asset("EURT", "Euro", "credit_alphanum4", KnownAccounts.Tempo),
-    "MOBI" : new Asset("MOBI", "Mobius", "credit_alphanum4", KnownAccounts.Mobius, 'https://mobius.network/mobi.png'),
     "SLT" : new Asset("SLT", "Smartlands token", "credit_alphanum4", KnownAccounts.SmartLands, 'https://smartlands.io/.well-known/KPUeW1N1.jpg'),
     "TERN" : new Asset("TERN", "Ternio.io TERN", "credit_alphanum4", KnownAccounts.Ternio),
     "USD-AnchorUsd": new Asset("USD", "US dollar", null, new Account("GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX", "anchorusd.com")),

--- a/src/app/services/asset.service.ts
+++ b/src/app/services/asset.service.ts
@@ -19,7 +19,6 @@ export class AssetService {
         KnownAssets['BTC-Interstellar'],
         KnownAssets["CNY-RippleFox"],
         KnownAssets.EURT,
-        KnownAssets.MOBI,
         KnownAssets.SLT
     ];
 


### PR DESCRIPTION
Improves performance as the GET request for their logo timed out. This is just a patchy solution, in long term we should address unavailable resources more generally.